### PR TITLE
Fix skip fastqc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Initial release of nf-core/dragen, created with the [nf-core](https://nf-co.re/)
 
 ### `Fixed`
 
-- Fixed error `Access to 'FASTQC_CHECK.out' is undefined since the workflow 'FASTQC_CHECK' has not been invoked before accessing the output attribute` when `-skip_fastqc` enabled by adjusting channel generation
+- Fixed error `Access to 'FASTQC.out' is undefined since the workflow 'FASTQC' has not been invoked before accessing the output attribute` when `-skip_fastqc` enabled by adjusting channel generation
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Initial release of nf-core/dragen, created with the [nf-core](https://nf-co.re/)
 
 ### `Fixed`
 
+- Fixed error `Access to 'FASTQC_CHECK.out' is undefined since the workflow 'FASTQC_CHECK' has not been invoked before accessing the output attribute` when `-skip_fastqc` enabled by adjusting channel generation
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/workflows/dragen.nf
+++ b/workflows/dragen.nf
@@ -84,11 +84,13 @@ workflow DRAGEN {
     //
     // MODULE: Run FastQC
     //
+    ch_multiqc_fastqc = Channel.empty()
     if (!params.skip_fastqc) {
         FASTQC (
             INPUT_CHECK.out.reads
         )
         ch_versions = ch_versions.mix(FASTQC.out.versions.first())
+        ch_multiqc_fastqc = FASTQC.out.zip
     }
 
     if (!params.skip_dragen) {
@@ -155,7 +157,7 @@ workflow DRAGEN {
     ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_custom_config.collect().ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_fastqc.collect{it[1]}.ifEmpty([]))
 
     MULTIQC (
         ch_multiqc_files.collect()


### PR DESCRIPTION
<!--
# nf-core/dragen pull request

Many thanks for contributing to nf-core/dragen!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/dragen/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

Enabling `--skip_fastqc` resulted in the error `Access to 'FASTQC.out' is undefined since the workflow 'FASTQC' has not been invoked before accessing the output attribute`. Fixed by initiating empty channel wherein FASTQC output can be stored if FASTQC run. Otherwise channel remains empty.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] `CHANGELOG.md` is updated.
