### PR TITLE
Use '?' instead of glob to handle individual FASTQ files better

### DIFF
--- a/modules/local/dragen.nf
+++ b/modules/local/dragen.nf
@@ -6,7 +6,7 @@ process DRAGEN {
     secret 'DRAGEN_PASSWORD'
 
     input:
-    tuple val(meta), path(fastq_1, stageAs: "input_S1_L001_R1_00*.fastq.gz"), path(fastq_2, stageAs: "input_S1_L001_R2_00*.fastq.gz")
+    tuple val(meta), path(fastq_1, stageAs: "input_S1_L001_R1_???.fastq.gz"), path(fastq_2, stageAs: "input_S1_L001_R2_???.fastq.gz")
     path index
 
     output:


### PR DESCRIPTION
The pipeline failed to handle a single pair of FASTQ files because it used a blank value for the glob. By switching to `???` it fills this in with an integer starting at 1 for every FASTQ. This should support up to 999 FASTQ pairs per sample.